### PR TITLE
ci: install golangci-lint via go install (install.sh is broken for v2.12+)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,12 @@ linters:
     - reassign
     - copyloopvar
     - staticcheck
+  settings:
+    goconst:
+      # Repeated literals in _test.go files are fixtures, not duplication.
+      # Test_RemoveDuplicates in particular feeds a list whose repetition is
+      # the thing under test, so hoisting it into a constant would obscure it.
+      ignore-tests: true
 
 formatters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 
+# Installed via `go install` rather than the upstream install.sh, which is
+# broken for every release from v2.12.0 onward: those releases added
+# `<tarball>.tar.gz.sbom.json` entries to checksums.txt, and install.sh looks
+# up the expected hash with a plain `grep <tarball-name>`. That pattern now
+# matches the tarball line AND the .sbom.json line, so the "expected" checksum
+# resolves to two values and verification can never succeed.
+GOLANGCI_LINT_VERSION ?= v2.12.2
+
 install-lint: ## Install go linter `golangci-lint`
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 lint: ## Lint
 	golangci-lint --version


### PR DESCRIPTION
The `Lint check` step has been failing on every PR — including Dependabot's — so the linter has not actually run in CI for some time.

```
golangci/golangci-lint info found version: 2.12.2 for v2.12.2/linux/amd64
golangci/golangci-lint err hash_sha256_verify checksum for
  golangci-lint-2.12.2-linux-amd64.tar.gz did not verify
make: *** [Makefile:3: install-lint] Error 1
```

### The release assets are fine — install.sh's lookup is ambiguous

My first read of this was "that release has bad checksums." That was wrong, and the real cause matters because it changes the fix.

From **v2.12.0** onward golangci-lint publishes `<tarball>.tar.gz.sbom.json` entries alongside the tarballs in `checksums.txt`. install.sh resolves the expected hash with a plain `grep <tarball-name>` — and the SBOM filename *contains* the tarball name as a prefix, so the grep matches **two** lines. The expected checksum resolves to two values and verification can never succeed.

```
grep 'linux-amd64.tar.gz' checksums.txt
  v2.11.4 -> 1 match     (50 entries, 0 .sbom.json)
  v2.12.2 -> 2 matches   (77 entries, 27 .sbom.json)
```

The two hashes in the error message are simply the tarball's and the SBOM's — both correct values straight out of `checksums.txt`. I confirmed the published tarball hashes to exactly the value install.sh was looking for.

### Fix: `go install`, not a version pin

This is upstream's bug and it will affect **every** future 2.12+ release, so pinning to v2.11.4 would freeze the linter indefinitely. Installing via `go install` bypasses install.sh entirely:

```make
GOLANGCI_LINT_VERSION ?= v2.12.2

install-lint:
	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
```

Overridable via the environment, and it fixes local `make install-lint` too.

### Second half: 3 new findings once the linter runs again

With lint actually executing, 2.12.2 reports 3 `goconst` issues that 2.11.4 did not — all in `_test.go`, all test fixtures:

```
avalanche_test.go:219  string `0/0` has 3 occurrences
common_test.go:43      string `0/0` has 3 occurrences
common_test.go:83      string `element0` has 3 occurrences
```

The clearest is `Test_RemoveDuplicates`, which feeds `RemoveDuplicates` a list whose repetition **is** the thing under test — hoisting `"element0"` into a constant would obscure the test rather than improve it. The others are BIP44 path suffixes in table data.

So this sets `goconst.ignore-tests` rather than contorting the fixtures. If you'd rather extract constants in the tests, say so and I'll swap the approach — it's three small edits.

### Verification

Local, on the final tree:

- `golangci-lint run` with 2.12.2 — **0 issues**
- `go install ...@v2.12.2` — installs cleanly (verified into a scratch GOBIN)
- `make build` — clean
- `make check-modtidy` — clean

### Relationship to #10

Independent, both based on `main`, no overlapping files — #10 touches `go.mod`/`go.sum` and the workflow, this touches `Makefile` and `.golangci.yml`. Merging this should turn #10 green too, since that PR is red for exactly this reason.
